### PR TITLE
[#223] Remove change img in universal mobile button

### DIFF
--- a/app/js/components/shared/controls.post.jsx
+++ b/app/js/components/shared/controls.post.jsx
@@ -79,7 +79,7 @@ export default class Controls extends React.Component {
       { mods: [1], key: 'up', text: 'Поднять объявление', link: `/up/${post.id}` },
       // TODO: add crud
       // { mods: [1], key: 'edit-post', text: 'Редактировать объявление', link: '/' },
-      { mods: [1], key: 'edit-pics', text: 'Редактировать изображения', link: '/' },
+      // { mods: [1], key: 'edit-pics', text: 'Редактировать изображения', link: '/' },
       { mods: [1], key: 'delete', text: 'Удалить' },
       { mods: [1, 2], key: 'comment', text: 'Написать комментарий', link: `/comments/${post.id}` },
       { mods: [2], key: 'price', text: 'Предложить цену', link: '/' },


### PR DESCRIPTION
Commented out the Edit-pics option in the universal button for mobile.