### PR TITLE
[#334] Change postslist h3 tag to h1

### DIFF
--- a/app/js/components/shared/posts.list.jsx
+++ b/app/js/components/shared/posts.list.jsx
@@ -427,7 +427,7 @@ class PostList extends React.Component {
         </Helmet>
 
         <div className='frontpage__block__head desktop'>
-          <h3 className='frontpage__block__title'>{ componentData.viewTitle }</h3>
+          <h1 className='frontpage__block__title'>{ componentData.viewTitle }</h1>
           { this.renderFrontpage() }
         </div>
 


### PR DESCRIPTION
Changed h3 tag to h1 in order for a page to have a proper heading.