### PR TITLE
Add reusable Img component

### DIFF
--- a/app/js/components/shared/Img.jsx
+++ b/app/js/components/shared/Img.jsx
@@ -45,4 +45,16 @@ class Img extends React.Component {
   }
 }
 
+/*eslint-disable */
+Img.propTypes = {
+  src: React.PropTypes.string.isRequired,
+  alt: React.PropTypes.string,
+  wrapperClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
+  imgClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
+  placeholderClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
+  onClick: React.PropTypes.func,
+  children: React.PropTypes.element,
+};
+/*eslint-enable */
+
 export default Img;

--- a/app/js/components/shared/Img.jsx
+++ b/app/js/components/shared/Img.jsx
@@ -12,13 +12,11 @@ class Img extends React.Component {
   componentDidMount() {
     const img = this.node.getBoundingClientRect();
     if (img.complete) {
-      console.log('waat');
       this.onImageLoad();
     }
   }
   componentWillReceiveProps(nextProps) {
     if (nextProps.src !== this.props.src) {
-      console.log('WHATATATAT');
       this.setState({ imgLoaded: false });
     }
   }

--- a/app/js/components/shared/Img.jsx
+++ b/app/js/components/shared/Img.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import classNames from 'classnames';
+import Spinner from '../shared/spinner';
+
+class Img extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onImageLoad = this.onImageLoad.bind(this);
+    this.state = { imgLoaded: false };
+  }
+
+  componentDidMount() {
+    const img = this.node.getBoundingClientRect();
+    if (img.complete) {
+      console.log('waat');
+      this.onImageLoad();
+    }
+  }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.src !== this.props.src) {
+      console.log('WHATATATAT');
+      this.setState({ imgLoaded: false });
+    }
+  }
+
+  onImageLoad() {
+    if (!this.state.imgLoaded) {
+      this.setState({ imgLoaded: true });
+    }
+  }
+
+  render() {
+    return (
+      <div className={ classNames('image-wrapper', this.props.wrapperClasses) } onClick={ this.props.onClick }>
+        <img
+          className={ classNames('image-rendered', this.props.imgClasses, (this.state.imgLoaded) ? '' : 'hidden') }
+          src={ this.props.src }
+          alt={ this.props.alt }
+          onLoad={ this.onImageLoad }
+          ref={ (node) => { this.node = node; } }
+        />
+        <div className={ classNames('image-placeholder', this.props.placeholderClasses, (this.state.imgLoaded) ? 'hidden' : '') } >
+          { this.props.children || <Spinner />}
+        </div>
+      </div>
+    );
+  }
+}
+
+export default Img;

--- a/app/js/components/shared/Img.jsx
+++ b/app/js/components/shared/Img.jsx
@@ -53,7 +53,7 @@ Img.propTypes = {
   imgClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
   placeholderClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
   onClick: React.PropTypes.func,
-  children: React.PropTypes.element,
+  children: React.PropTypes.node,
 };
 /*eslint-enable */
 

--- a/app/js/components/shared/Img.jsx
+++ b/app/js/components/shared/Img.jsx
@@ -49,9 +49,9 @@ class Img extends React.Component {
 Img.propTypes = {
   src: React.PropTypes.string.isRequired,
   alt: React.PropTypes.string,
-  wrapperClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
-  imgClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
-  placeholderClasses: React.PropTypes.oneOfType([React.propTypes.string, React.PropTypes.array]),
+  wrapperClasses: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array]),
+  imgClasses: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array]),
+  placeholderClasses: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.array]),
   onClick: React.PropTypes.func,
   children: React.PropTypes.node,
 };

--- a/app/style/style.scss
+++ b/app/style/style.scss
@@ -437,3 +437,34 @@
 .error {
   color: #f71616;
 }
+
+/*
+=== Img component styles ===
+*/
+.image-wrapper {
+  position: relative;
+  width: 100%;
+  height: inherit;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  overflow: hidden;
+}
+.image-rendered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: 1;
+  opacity: 1;
+  transition: opacity 0.6s ease-in;
+}
+.image-placeholder {
+  z-index: 2;
+  opacity: 1;
+  width: 100%;
+}
+.image-placeholder.hidden, .image-rendered.hidden {
+  opacity: 0;
+  z-index: 0;
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "axios": "^0.15.3",
     "babel-cli": "6.16.0",
     "babel-polyfill": "6.16.0",
+    "classnames": "^2.2.5",
     "google-map-react": "^0.24.0",
     "html-webpack-plugin": "^2.28.0",
     "img": "^3.0.3",


### PR DESCRIPTION
This component would display a placeholder component until the passed img src finishes loading.
Example use:
```
import Img from '../shared/Img';  
const SimpleComponent = ()  => (
  <div>
    <Img src='example.png' />
    <p>Hello!</p>
  </div> 
);
export default SimpleComponent;
```
You can pass your own placeholder node, defaults to the Spinner component:
```
<Img src='example.png' >
  <FancyPlaceholder />
</Img>
```

List of accepted props: 
```
Img.propTypes = {
  src: PropTypes.string.isRequired,
  alt: PropTypes.string,
  wrapperClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
  imgClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
  placeholderClasses: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
  onClick: PropTypes.func,
  children: PropTypes.node,
};
```

Please review, any feedback is welcome.